### PR TITLE
[SOLA-809] Clicking on facets (headless)

### DIFF
--- a/commands/CoveoSearch.js
+++ b/commands/CoveoSearch.js
@@ -1,5 +1,5 @@
 module.exports = class CoveoSearch {
-  async command(text, searchinterface = "", selector = ".CoveoSearchbox .magic-box-input > input") {
+  async command(text, searchinterface = "", selector = ".CoveoSearchbox .magic-box-input > input, #search-box") {
     const inputBoxSelector = `${searchinterface} ${selector}`;
 
     let result = await this.api.waitForElementVisible(inputBoxSelector);
@@ -16,9 +16,6 @@ module.exports = class CoveoSearch {
 
     await this.api.pause(1000);
     await this.api.CoveoWaitForSearch(lastSearchUid);
-
-    await this.api.waitForElementPresent('.CoveoSearchInterface.coveo-after-initialization');
-    await this.api.waitForElementNotPresent('.CoveoSearchInterface.coveo-after-initialization.coveo-executing-query');
 
     return (result.status !== -1);
   }

--- a/commands/CoveoSelectFacetValue.js
+++ b/commands/CoveoSelectFacetValue.js
@@ -14,32 +14,41 @@ module.exports = class CoveoSelectFacetValue {
           return resolve();
         }
 
-        await this.api.waitForElementNotPresent(`li.coveo-selected[data-value="${facetValue}"]`);
-        await this.api.click(`li[data-value="${facetValue}"]`);
-      } else {
+        await this.api.waitForElementNotPresent(`li.coveo-selected[data-value="${facetValue}"], li.coveo-selected[data-facet-value="${facetValue}"]`);
+        await this.api.click(`li[data-value="${facetValue}"], li[data-facet-value="${facetValue}"]`);
+      }
+      else {
         if (!aq.includes(`"${facetValue}"`)) {
           console.log('**** ALREADY SELECTED NOT IN QUERY, DO NOTHING');
           return resolve();
         }
 
-        await this.api.waitForElementPresent(`li.coveo-selected[data-value="${facetValue}"]`);
-        await this.api.click(`li.coveo-selected[data-value="${facetValue}"]`);
+        await this.api.waitForElementPresent(`li.coveo-selected[data-value="${facetValue}"], li.coveo-selected[data-facet-value="${facetValue}"]`);
+        await this.api.click(`li.coveo-selected[data-value="${facetValue}"], li.coveo-selected[data-facet-value="${facetValue}"]`);
       }
+
       lastResponse = await this.api.CoveoWaitForSearch(lastSearchUid);
 
-      let validatedFacet = false;
-      while (!validatedFacet) {
-        lastResponse = await this.api.getLastResponse();
-        aq = (lastResponse.query && lastResponse.query.aq) || '';
-        const aqHasValue = aq.includes(`"${facetValue}"`);
-        if ((selectValue && aqHasValue) || (!selectValue && !aqHasValue)) {
-          // facet was applied
-          validatedFacet = true;
-          return resolve({ status: 0 });
-        } else {
-          // try again after a pause;
-          await this.api.pause(250);
+      if (this.api.globals._HAS_SPY) {
+        // JSUI - Validate the facet value is in AQ
+        let validatedFacet = false;
+        while (!validatedFacet) {
+          lastResponse = await this.api.getLastResponse();
+          aq = (lastResponse.query && lastResponse.query.aq) || '';
+          const aqHasValue = aq.includes(`"${facetValue}"`);
+          if ((selectValue && aqHasValue) || (!selectValue && !aqHasValue)) {
+            // facet was applied
+            validatedFacet = true;
+            return resolve({ status: 0 });
+          } else {
+            // try again after a pause;
+            await this.api.pause(250);
+          }
         }
+      }
+      else {
+        // Headless - no validation of search state yet
+        return resolve({ status: 0 });
       }
     });
   }

--- a/commands/getLastResponse.js
+++ b/commands/getLastResponse.js
@@ -1,13 +1,26 @@
 module.exports = class getLastResponse {
-  command() {
-    return new Promise(resolve => {
-      this.api.executeAsync(function (done) {
-        setTimeout(() => done(window._LAST_COVEO_RESPONSE), 1);
-      }, (result) => {
-        let response = JSON.parse(result.value) || {};
-        // console.log('LastResponse:', response.searchUid);
-        resolve(response);
+  async command() {
+    if (this.api.globals._HAS_SPY) {
+      // using JSUI "spy"
+      return new Promise(resolve => {
+        this.api.executeAsync(function (done) {
+          setTimeout(() => done(window._LAST_COVEO_RESPONSE), 1);
+        }, (result) => {
+          let response = JSON.parse(result.value) || {};
+          // console.log('LastResponse:', response.searchUid);
+          resolve(response);
+        });
       });
-    });
+    }
+
+    // in Headless, we set the data-search-uid on the result list, so we can track when it changes
+    let result = await this.api.waitForElementPresent('*[data-search-uid]', 1000, false);
+    if (result.status !== -1) {
+      result = await this.api.getAttribute('*[data-search-uid]', 'data-search-uid');
+      if (result !== -1) {
+        return { searchUid: result.value };
+      }
+    }
+    return { searchUid: '' };
   }
 };

--- a/commands/setCoveoSpy.js
+++ b/commands/setCoveoSpy.js
@@ -2,6 +2,9 @@ module.exports = class setCoveoSpy {
   async command(selector = ".CoveoSearchInterface") {
     await this.api.waitForElementPresent(selector);
     return new Promise(resolve => {
+
+      this.api.globals._HAS_SPY = true; // used by getLastResponse to validate if the SPY is used.
+
       this.api.executeAsync(function (selector, done) { // leave as "function()", syntax like "()=>{}" will not work here.
         Coveo.$$(document.querySelector(selector, Coveo.SearchInterface)).on('querySuccess', (e, args) => {
           const { query } = args;

--- a/src/storefront_bestbuy.js
+++ b/src/storefront_bestbuy.js
@@ -1,0 +1,24 @@
+describe("BestBuy (Storefront headless)", function () {
+  //Keep browser open when fails
+  this.endSessionOnFail = true;
+  this.abortOnElementLocateError = false;
+  this.abortOnAssertionFailure = false;
+  this.waitForConditionTimeout = 5000;
+
+  beforeEach(async function (browser) {
+    await browser.resizeWindow(1565, 1237);
+    // await browser.url("https://genericstore.coveodemo.com/");
+    await browser.url("http://localhost:3000/searchPage");
+  });
+
+  test("washer DNE", async function (browser) {
+    await browser.CoveoSearch("Washer");
+
+    await browser.CoveoSelectFacetValue("Appliances");
+    await browser.CoveoSelectFacetValue("Washers & Dryers");
+    await browser.CoveoSelectFacetValue("Washing Machines");
+
+  });
+
+  afterEach(browser => browser.end());
+});


### PR DESCRIPTION
( Related to https://github.com/coveo/storefront-headless/pull/44 )

I started updating the custom commands for Search , WaitForSearch and SelectFacetValue for use with the storefront-headless. 

1. CoveoSearch is using the default id `#search-box` to find the right search box in headless
2. CoveoSelectFacetValue is making sure the facet wasn't previously set, click on facet, then wait for search to happen. it's using the data-facet-value attribute by default, and the .coveo-selected css class
3. getLastResponse is to return the last searchUid. Re-using the data-search-uid set on the result list in the storefront-headless project. quick and simple way to track when search updates the result list.

So a real basic scenario for training DNE can be something like this: 
```
    await browser.CoveoSearch("Washer");

    await browser.CoveoSelectFacetValue("Appliances");
    await browser.CoveoSelectFacetValue("Washers & Dryers");
    await browser.CoveoSelectFacetValue("Washing Machines");
```

This is still Work In Progress, I will add selecting a result item at random after the last facet selection. 