### PR TITLE
[SOLA-809] generate traffic for auto select

### DIFF
--- a/commands/CoveoIsVisible.js
+++ b/commands/CoveoIsVisible.js
@@ -1,0 +1,14 @@
+module.exports = class CoveoIsVisible {
+  async command(using, selector) {
+    if (!selector) {
+      selector = using;
+      using = 'css selector';
+    }
+    let results = await this.api.elements(using, selector);
+    if (results.status !== 0) {
+      return false;
+    }
+
+    return (results.value.length > 0);
+  };
+};

--- a/commands/CoveoOpenResult.js
+++ b/commands/CoveoOpenResult.js
@@ -6,6 +6,9 @@ module.exports = class CoveoOpenResult {
 
   async command(nthValue = "RND", closeWindow = false, resultlist = "", max = 5, specific = "") {
     if (nthValue === "RND") {
+      let results = await this.api.elements('css selector', `${resultlist} .CoveoResultList .CoveoResult`);
+      max = Math.min(max, results?.value?.length || 1);
+
       nthValue = this.getRandomInt(1, max);
     }
 

--- a/commands/CoveoSearch.js
+++ b/commands/CoveoSearch.js
@@ -5,16 +5,25 @@ module.exports = class CoveoSearch {
     let result = await this.api.waitForElementVisible(inputBoxSelector);
     if (result.status == -1) return false;
 
-    result = await this.api.clearValue(inputBoxSelector);
-    if (result.status == -1) return false;
+    await this.api.click(inputBoxSelector);
+    await this.api.pause(500);
 
+    let clearButton = await this.api.CoveoIsVisible('button.MuiAutocomplete-clearIndicator.MuiAutocomplete-clearIndicatorDirty');
+    if (clearButton === true) { // need to check with 'true' because value would be an object in case of error.
+      result = await this.api.click('button.MuiAutocomplete-clearIndicator');
+      await this.api.pause(500);
+    }
+    else {
+      result = await this.api.clearValue(inputBoxSelector);
+    }
+    if (result.status == -1) return false;
 
     let lastSearchUid = (await this.api.getLastResponse()).searchUid;
 
+    await this.api.click(inputBoxSelector);
     result = await this.api.setValue(inputBoxSelector, text);
     result = await this.api.keys(this.api.Keys.ENTER);
 
-    await this.api.pause(1000);
     await this.api.CoveoWaitForSearch(lastSearchUid);
 
     return (result.status !== -1);

--- a/commands/CoveoSearch.js
+++ b/commands/CoveoSearch.js
@@ -25,6 +25,7 @@ module.exports = class CoveoSearch {
     result = await this.api.keys(this.api.Keys.ENTER);
 
     await this.api.CoveoWaitForSearch(lastSearchUid);
+    await this.api.pause(1000); // slow down a bit for UA events
 
     return (result.status !== -1);
   }

--- a/commands/getLastResponse.js
+++ b/commands/getLastResponse.js
@@ -14,9 +14,9 @@ module.exports = class getLastResponse {
     }
 
     // in Headless, we set the data-search-uid on the result list, so we can track when it changes
-    let result = await this.api.waitForElementPresent('*[data-search-uid]', 1000, false);
-    if (result.status !== -1) {
-      result = await this.api.getAttribute('*[data-search-uid]', 'data-search-uid');
+    let hasSearchUid = await this.api.CoveoIsVisible('*[data-search-uid]');
+    if (hasSearchUid) {
+      let result = await this.api.getAttribute('*[data-search-uid]', 'data-search-uid');
       if (result !== -1) {
         return { searchUid: result.value };
       }

--- a/src/storefront_bestbuy.js
+++ b/src/storefront_bestbuy.js
@@ -18,6 +18,7 @@ describe("BestBuy (Storefront headless)", function () {
     await browser.CoveoSelectFacetValue("Washers & Dryers");
     await browser.CoveoSelectFacetValue("Washing Machines");
 
+    await browser.CoveoSearch("Dryer");
   });
 
   afterEach(browser => browser.end());

--- a/src/storefront_bestbuy.js
+++ b/src/storefront_bestbuy.js
@@ -8,17 +8,38 @@ describe("BestBuy (Storefront headless)", function () {
   beforeEach(async function (browser) {
     await browser.resizeWindow(1565, 1237);
     // await browser.url("https://genericstore.coveodemo.com/");
-    await browser.url("http://localhost:3000/searchPage");
+    await browser.url("http://localhost:3000");
   });
 
-  test("washer DNE", async function (browser) {
+  test("DNE - Washer", async function (browser) {
     await browser.CoveoSearch("Washer");
 
     await browser.CoveoSelectFacetValue("Appliances");
     await browser.CoveoSelectFacetValue("Washers & Dryers");
     await browser.CoveoSelectFacetValue("Washing Machines");
 
+    await browser.CoveoOpenResult("RND");
+  });
+
+  test("DNE - Dryer", async function (browser) {
     await browser.CoveoSearch("Dryer");
+
+    await browser.CoveoSelectFacetValue("Appliances");
+    await browser.CoveoSelectFacetValue("Washers & Dryers");
+    await browser.CoveoSelectFacetValue("Dryers");
+
+    await browser.CoveoOpenResult("RND");
+  });
+
+  test("DNE - Hand Dryer", async function (browser) {
+    await browser.CoveoSearch("Hand Dryer");
+
+    await browser.CoveoSelectFacetValue("Appliances");
+    await browser.CoveoSelectFacetValue("Small Kitchen Appliances");
+    await browser.CoveoSelectFacetValue("Kitchen Gadgets");
+    await browser.CoveoSelectFacetValue("Soap Dispensers & Hand Dryers");
+
+    await browser.CoveoOpenResult("RND");
   });
 
   afterEach(browser => browser.end());

--- a/src/storefront_bestbuy.js
+++ b/src/storefront_bestbuy.js
@@ -7,8 +7,8 @@ describe("BestBuy (Storefront headless)", function () {
 
   beforeEach(async function (browser) {
     await browser.resizeWindow(1565, 1237);
-    // await browser.url("https://genericstore.coveodemo.com/");
-    await browser.url("http://localhost:3000");
+    await browser.url("https://genericstore.coveodemo.com/");
+    // await browser.url("http://localhost:3000");
   });
 
   test("DNE - Washer", async function (browser) {
@@ -18,7 +18,7 @@ describe("BestBuy (Storefront headless)", function () {
     await browser.CoveoSelectFacetValue("Washers & Dryers");
     await browser.CoveoSelectFacetValue("Washing Machines");
 
-    await browser.CoveoOpenResult("RND");
+    await browser.CoveoOpenResult();
   });
 
   test("DNE - Dryer", async function (browser) {
@@ -28,7 +28,7 @@ describe("BestBuy (Storefront headless)", function () {
     await browser.CoveoSelectFacetValue("Washers & Dryers");
     await browser.CoveoSelectFacetValue("Dryers");
 
-    await browser.CoveoOpenResult("RND");
+    await browser.CoveoOpenResult();
   });
 
   test("DNE - Hand Dryer", async function (browser) {
@@ -39,7 +39,59 @@ describe("BestBuy (Storefront headless)", function () {
     await browser.CoveoSelectFacetValue("Kitchen Gadgets");
     await browser.CoveoSelectFacetValue("Soap Dispensers & Hand Dryers");
 
-    await browser.CoveoOpenResult("RND");
+    await browser.CoveoOpenResult();
+  });
+
+  test("DNE - wireless headphones", async function (browser) {
+    await browser.CoveoSearch("wireless headphones");
+
+    await browser.CoveoSelectFacetValue("Audio");
+    await browser.CoveoSelectFacetValue("Headphones");
+
+    await browser.CoveoOpenResult();
+  });
+
+
+  test("DNE - ipad pro", async function (browser) {
+    await browser.CoveoSearch("ipad pro");
+
+    await browser.CoveoSelectFacetValue("Computers & Tablets");
+    await browser.CoveoSelectFacetValue("Tablets");
+    await browser.CoveoSelectFacetValue("Apple iPad");
+    await browser.CoveoSelectFacetValue("iPad Pro");
+
+    await browser.CoveoOpenResult();
+  });
+
+  test("DNE - flashlight", async function (browser) {
+    await browser.CoveoSearch("flashlight");
+
+    await browser.CoveoSelectFacetValue("Home, Furniture & Office");
+    await browser.CoveoSelectFacetValue("Lighting");
+    await browser.CoveoSelectFacetValue("Flashlights & Portable Lights");
+
+    await browser.CoveoSearch("flashlight led");
+
+    await browser.CoveoOpenResult();
+  });
+
+  test("DNE - baby shark", async function (browser) {
+    await browser.CoveoSearch("");
+
+    await browser.click("#category-facet--ec_category .CoveoFacetShowMore");
+    await browser.CoveoSelectFacetValue("Toys, Games & Collectibles");
+
+    await browser.click("#category-facet--ec_category .CoveoFacetShowMore");
+    await browser.CoveoSelectFacetValue("Toys");
+
+    await browser.click("#category-facet--ec_category .CoveoFacetShowMore");
+    await browser.pause(1000);
+    await browser.click("#category-facet--ec_category .CoveoFacetShowMore");
+    await browser.CoveoSelectFacetValue("Surprise Toys");
+
+    await browser.CoveoSearch("baby shark");
+
+    await browser.CoveoOpenResult();
   });
 
   afterEach(browser => browser.end());


### PR DESCRIPTION
adding CoveoIsVisible command to check if an element is visible currently. It returns a simple `true/false`. 

This is needed because Nightwatch's isVisible() was still flagging a test as Fail in case something is not visible. 
CoveoIsVisible can be useful to validate something like if a searchbox has a clear button or not (the button is only present when there is currently text in the search box for example)

Also Adding more scenarios to DNE for Dryers. 